### PR TITLE
Remove recursive call for pull out items from dropdown

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,24 +35,17 @@
         el: "#debt-collective-header",
         data: {
           headerLinks: [
-            { text: "Home", href: "/" },
-            { text: "Dispute Your Debt", href: "#debt" },
-            { text: "Campaings", href: "#camp" },
-            { text: "Events", href: "#events" },
-            { text: "News", href: "#news" },
-            {
-              text: "Dispute Your Debt",
-              href: "#dispute-your-debt",
-              onclick: "window.loggit()"
-            },
-            {
-              text: "Admin Link Only",
-              href: "#dispute-your-asdf",
-              onclick: "window.loggit()",
-              roles: ["admins"]
-            }
+            { text: 'Admin', href: '/admin/disputes', roles: ['admin'] },
+            { text: 'My Disputes', href: '/disputes/my' },
+            { text: 'Dispute Your Debt', href: '/' },
+            { text: 'Community', href: 'https://community.debtcollective.org' },
+            { text: 'Events', href: 'https://community.debtcollective.org/calendar' },
+            { text: 'The Power Report', href: 'https://powerreport.debtcollective.org' },
+            { text: "Donate", href: "http://tools.debtcollective.org/donate" },
           ],
-          dropdownLinks: []
+          dropdownLinks: [
+            { text: 'About the Debt Collective', href: 'https://debtcollective.org#about' }
+          ]
         }
       });
     </script>

--- a/src/utils/responsiveness.js
+++ b/src/utils/responsiveness.js
@@ -88,9 +88,6 @@ export const priorityPattern = container => {
       );
       dropdownContainerUl && dropdownContainerUl.removeChild(firstOnDropdown);
     }
-
-    // In case we need to move more than one item for certain pixel width
-    priorityPattern(container);
   }
 
   toggleDropdownVisibility(dropdown);


### PR DESCRIPTION
Closes https://github.com/debtcollective/parent/issues/267

_Fixes:_
- Remove recursive call for pullout items from the dropdown to avoid Max call stack error

_Chores:_
- Update the header config to be similar to the production one

![http://recordit.co/enlxJwfW6s](http://recordit.co/enlxJwfW6s.gif)

# Notes
The original script for Priority pattern actually does not show the recursive call for pulling out the items, seems like the problem was caused from constantly meet the possibility of hide and then pull out which causes an infinite loop.